### PR TITLE
Fixes issue with default height and width

### DIFF
--- a/src/components/cpu/irq-average/irq-average.js
+++ b/src/components/cpu/irq-average/irq-average.js
@@ -20,8 +20,8 @@ export class IrqAverage extends HTMLElement {
     connectedCallback() {
         var defaults = new Defaults();
         var margin = this.dataset.margin || defaults.margin;
-        var height = (this.dataset.height || defaults.height) - margin.top - margin.bottom;
-        var width = (this.dataset.width || defaults.width) - margin.left - margin.right;
+        var height = (this.dataset.height || defaults.graphHeight) - margin.top - margin.bottom;
+        var width = (this.dataset.width || defaults.graphWidth) - margin.left - margin.right;
         var lineColor = this.dataset.lineColor || defaults.lineColor;
 
         this.innerHTML = "<line-graph data-margin=" + JSON.stringify(margin) + 


### PR DESCRIPTION
## JIRA:
See ticket here - https://jira.rax.io/browse/MNRVA-68

## Description:

When the height and width of a graph is not specified then the graph should honor the default values.  There was an issue that this PR fixes where it was looking for the wrong object key from the defaults class, in turn rendering the graph unexpectedly.

## Testing:

Modify a graph to have no height and width specified and observe the magic

## Screenshots:
(if applicable)