### PR TITLE
HTTP Graphs added

### DIFF
--- a/backstop.js
+++ b/backstop.js
@@ -1,7 +1,7 @@
 const glob = require('glob-promise');
 const backstop = require('backstopjs');
 var args = require('minimist')(process.argv.slice(2));
-const componentPath = './src/components';
+const componentPath = './test/components';
 const config = require('./_config');
 const server = require('./bin/server');
 

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -6,4 +6,4 @@ steps:
     args: ["npm", "run", "visual-test"]
 
   - name: 'gcr.io/cloud-builders/gsutil'
-    args: ["rsync", "-r", "test", "gs://hedwig-backstop.mnrva-deploy.dev.monplat.rackspace.net/$REPO_NAME/$BRANCH_NAME/$COMMIT_SHA/"]
+    args: ["rsync", "-r", "test/backstop_data", "gs://hedwig-backstop.mnrva-deploy.dev.monplat.rackspace.net/$REPO_NAME/$BRANCH_NAME/$COMMIT_SHA/"]

--- a/docs/_includes/http/http-bytes.html
+++ b/docs/_includes/http/http-bytes.html
@@ -1,0 +1,104 @@
+<div id='http-bytes'>
+        <h3></h3>
+        <div>
+          <p>
+            Description:<br><br>
+            This check will try to connect to the server and retrieve the specified
+            URL using the specified method, optionally with the password and user
+            for authentication, using SSL, and checking the body with a regex.
+          </p>
+          <br>
+          <p>
+            Tag: <br>
+            <pre><code class='html'>&lt;hedwig-graph data-type="http-bytes" data-height="200" data-width="400" data-unit="b" data={{ someBoundData }} &gt;&lt;/hedwig-graph&gt;</code></pre>
+          </p>
+          <br>
+          <p>Sample data structure</p>
+          <pre><code>
+    [{
+      "bytes": 8958,
+      "time": "2018-11-24T18:58:21Z"
+      },
+      {
+          "bytes": 735,
+          "time": "2018-11-25T23:58:21Z"
+      },
+      {
+          "bytes": 115,
+          "time": "2018-11-26T02:58:21Z"
+      },
+      {
+          "bytes": 742,
+          "time": "2018-11-27T10:58:21Z"
+    }]
+            </code></pre>
+            <br><br>
+            <p>
+                Renders: <br>
+              </p>
+              <script>
+                  var mock = [
+                {
+                    "bytes": 8958,
+                    "time": "2018-11-24T18:58:21Z"
+                },
+                {
+                    "bytes": 735,
+                    "time": "2018-11-25T23:58:21Z"
+                },
+                {
+                    "bytes": 115,
+                    "time": "2018-11-26T02:58:21Z"
+                },
+                {
+                    "bytes": 742,
+                    "time": "2018-11-27T10:58:21Z"
+                }];
+
+                  document.write('<hedwig-graph data-type="http-bytes" data-height="200" data-width="400" data-unit="kb" data-graph=' + JSON.stringify(mock) + '></hedwig-graph>');
+              </script>
+
+              <p>Options</p>
+              <table class='hxTable hxTable--condensed'>
+                <thead>
+                  <tr>
+                    <th>Name</th>
+                    <th>Required</th>
+                    <th>Default Value</th>
+                  </tr>
+                </thead>
+                <tbody>
+                    <tr>
+                      <td>Type</td>
+                      <td>yes</td>
+                      <td>http-bytes</td>
+                    </tr>
+                  <tr>
+                    <td>Margin</td>
+                    <td>no</td>
+                    <td>{ top: 50, right: 50, bottom: 50, left: 50 }</td>
+                  </tr>
+                  <tr>
+                    <td>Height</td>
+                    <td>no</td>
+                    <td>200</td>
+                  </tr>
+                  <tr>
+                    <td>Weight</td>
+                    <td>no</td>
+                    <td>600</td>
+                  </tr>
+                  <tr>
+                      <td>Line Color</td>
+                      <td>no</td>
+                      <td>#0c7c84</td>
+                    </tr>
+                    <tr>
+                      <td>Unit</td>
+                      <td>no</td>
+                      <td>b</td>
+                    </tr>
+                </tbody>
+              </table>
+        </div>
+    </div>

--- a/docs/_includes/http/http-cert-bits.html
+++ b/docs/_includes/http/http-cert-bits.html
@@ -1,0 +1,102 @@
+<div id='http-cert-bits'>
+        <h3></h3>
+        <div>
+          <p>
+            Description:<br><br>
+            This check will attempt to check the certificate for bits returned.
+          </p>
+          <br>
+          <p>
+            Tag: <br>
+            <pre><code class='html'>&lt;hedwig-graph data-type="http-cert-bits" data-height="200" data-width="400" data-unit="other" data={{ someBoundData }} &gt;&lt;/hedwig-graph&gt;</code></pre>
+          </p>
+          <br>
+          <p>Sample data structure</p>
+          <pre><code>
+    [{
+      "cert_bits": 2048,
+      "time": "2018-11-24T18:58:21Z"
+  },
+  {
+      "cert_bits": 2048,
+      "time": "2018-11-25T23:58:21Z"
+  },
+  {
+      "cert_bits": 2048,
+      "time": "2018-11-26T02:58:21Z"
+  },
+  {
+      "cert_bits": 2048,
+      "time": "2018-11-27T10:58:21Z"
+  }]
+            </code></pre>
+            <br><br>
+            <p>
+                Renders: <br>
+              </p>
+              <script>
+                  var mock = [
+                  {
+                    "cert_bits": 2048,
+                    "time": "2018-11-24T18:58:21Z"
+                  },
+                  {
+                    "cert_bits": 2048,
+                    "time": "2018-11-25T23:58:21Z"
+                  },
+                  {
+                    "cert_bits": 2048,
+                    "time": "2018-11-26T02:58:21Z"
+                  },
+                  {
+                    "cert_bits": 2048,
+                    "time": "2018-11-27T10:58:21Z"
+                  }];
+
+                  document.write('<hedwig-graph data-type="http-cert-bits" data-height="200" data-width="400" data-unit="other" data-graph=' + JSON.stringify(mock) + '></hedwig-graph>');
+              </script>
+
+              <p>Options</p>
+              <table class='hxTable hxTable--condensed'>
+                <thead>
+                  <tr>
+                    <th>Name</th>
+                    <th>Required</th>
+                    <th>Default Value</th>
+                  </tr>
+                </thead>
+                <tbody>
+                    <tr>
+                      <td>Type</td>
+                      <td>yes</td>
+                      <td>http-cert-bits</td>
+                    </tr>
+                  <tr>
+                    <td>Margin</td>
+                    <td>no</td>
+                    <td>{ top: 50, right: 50, bottom: 50, left: 50 }</td>
+                  </tr>
+                  <tr>
+                    <td>Height</td>
+                    <td>no</td>
+                    <td>200</td>
+                  </tr>
+                  <tr>
+                    <td>Weight</td>
+                    <td>no</td>
+                    <td>600</td>
+                  </tr>
+                  <tr>
+                      <td>Line Color</td>
+                      <td>no</td>
+                      <td>#0c7c84</td>
+                    </tr>
+                    <tr>
+                      <td>Unit</td>
+                      <td>no</td>
+                      <td>b</td>
+                    </tr>
+                </tbody>
+              </table>
+        </div>
+    </div>

--- a/docs/_includes/http/http-cert-end-in.html
+++ b/docs/_includes/http/http-cert-end-in.html
@@ -1,0 +1,103 @@
+<div id='http-cert-end-in'>
+        <h3></h3>
+        <div>
+          <p>
+            Description:<br><br>
+            The relative timestamp in seconds until certification expiration.
+            This is only available when performing a check on an HTTPS server.
+          </p>
+          <br>
+          <p>
+            Tag: <br>
+            <pre><code class='html'>&lt;hedwig-graph data-type="http-cert-end-in" data-height="200" data-width="400" data-unit="other" data={{ someBoundData }} &gt;&lt;/hedwig-graph&gt;</code></pre>
+          </p>
+          <br>
+          <p>Sample data structure</p>
+          <pre><code>
+    [{
+      "cert_end_in": 43575551,
+      "time": "2018-11-24T18:58:21Z"
+  },
+  {
+      "cert_end_in": 12385150,
+      "time": "2018-11-25T23:58:21Z"
+  },
+  {
+      "cert_end_in": 47204350,
+      "time": "2018-11-26T02:58:21Z"
+  },
+  {
+      "cert_end_in": 12385150,
+      "time": "2018-11-27T10:58:21Z"
+  }]
+            </code></pre>
+            <br><br>
+            <p>
+                Renders: <br>
+              </p>
+              <script>
+                  var mock = [
+                  {
+                    "cert_end_in": 43575551,
+                    "time": "2018-11-24T18:58:21Z"
+                },
+                {
+                    "cert_end_in": 12385150,
+                    "time": "2018-11-25T23:58:21Z"
+                },
+                {
+                    "cert_end_in": 47204350,
+                    "time": "2018-11-26T02:58:21Z"
+                },
+                {
+                    "cert_end_in": 12385150,
+                    "time": "2018-11-27T10:58:21Z"
+                }];
+
+                  document.write('<hedwig-graph data-type="http-cert-end-in" data-height="200" data-width="400" data-unit="other" data-graph=' + JSON.stringify(mock) + '></hedwig-graph>');
+              </script>
+
+              <p>Options</p>
+              <table class='hxTable hxTable--condensed'>
+                <thead>
+                  <tr>
+                    <th>Name</th>
+                    <th>Required</th>
+                    <th>Default Value</th>
+                  </tr>
+                </thead>
+                <tbody>
+                    <tr>
+                      <td>Type</td>
+                      <td>yes</td>
+                      <td>http-cert-end-in</td>
+                    </tr>
+                  <tr>
+                    <td>Margin</td>
+                    <td>no</td>
+                    <td>{ top: 50, right: 50, bottom: 50, left: 50 }</td>
+                  </tr>
+                  <tr>
+                    <td>Height</td>
+                    <td>no</td>
+                    <td>200</td>
+                  </tr>
+                  <tr>
+                    <td>Weight</td>
+                    <td>no</td>
+                    <td>600</td>
+                  </tr>
+                  <tr>
+                      <td>Line Color</td>
+                      <td>no</td>
+                      <td>#0c7c84</td>
+                    </tr>
+                    <tr>
+                      <td>Unit</td>
+                      <td>no</td>
+                      <td>other</td>
+                    </tr>
+                </tbody>
+              </table>
+        </div>
+    </div>

--- a/docs/_includes/http/http-cert-end.html
+++ b/docs/_includes/http/http-cert-end.html
@@ -1,0 +1,103 @@
+<div id='http-cert-end'>
+        <h3></h3>
+        <div>
+          <p>
+            Description:<br><br>
+            The absolute timestamp in seconds for the certificate expiration.
+            This is only available when performing a check on an HTTPS server.
+          </p>
+          <br>
+          <p>
+            Tag: <br>
+            <pre><code class='html'>&lt;hedwig-graph data-type="http-cert-end" data-height="200" data-width="400" data-unit="other" data={{ someBoundData }} &gt;&lt;/hedwig-graph&gt;</code></pre>
+          </p>
+          <br>
+          <p>Sample data structure</p>
+          <pre><code>
+    [{
+      "cert_end": 1593043199,
+      "time": "2018-11-24T18:58:21Z"
+  },
+  {
+      "cert_end": 1593043199,
+      "time": "2018-11-25T23:58:21Z"
+  },
+  {
+      "cert_end": 1596671999,
+      "time": "2018-11-26T02:58:21Z"
+  },
+  {
+      "cert_end": 1596671999,
+      "time": "2018-11-27T10:58:21Z"
+  }]
+            </code></pre>
+            <br><br>
+            <p>
+                Renders: <br>
+              </p>
+              <script>
+                  var mock = [
+                  {
+                    "cert_end": 1593043199,
+                    "time": "2018-11-24T18:58:21Z"
+                },
+                {
+                    "cert_end": 1593043199,
+                    "time": "2018-11-25T23:58:21Z"
+                },
+                {
+                    "cert_end": 1596671999,
+                    "time": "2018-11-26T02:58:21Z"
+                },
+                {
+                    "cert_end": 1596671999,
+                    "time": "2018-11-27T10:58:21Z"
+                }];
+
+                  document.write('<hedwig-graph data-type="http-cert-end" data-height="200" data-width="400" data-unit="other" data-graph=' + JSON.stringify(mock) + '></hedwig-graph>');
+              </script>
+
+              <p>Options</p>
+              <table class='hxTable hxTable--condensed'>
+                <thead>
+                  <tr>
+                    <th>Name</th>
+                    <th>Required</th>
+                    <th>Default Value</th>
+                  </tr>
+                </thead>
+                <tbody>
+                    <tr>
+                      <td>Type</td>
+                      <td>yes</td>
+                      <td>http-certs-bit</td>
+                    </tr>
+                  <tr>
+                    <td>Margin</td>
+                    <td>no</td>
+                    <td>{ top: 50, right: 50, bottom: 50, left: 50 }</td>
+                  </tr>
+                  <tr>
+                    <td>Height</td>
+                    <td>no</td>
+                    <td>200</td>
+                  </tr>
+                  <tr>
+                    <td>Weight</td>
+                    <td>no</td>
+                    <td>600</td>
+                  </tr>
+                  <tr>
+                      <td>Line Color</td>
+                      <td>no</td>
+                      <td>#0c7c84</td>
+                    </tr>
+                    <tr>
+                      <td>Unit</td>
+                      <td>no</td>
+                      <td>other</td>
+                    </tr>
+                </tbody>
+              </table>
+        </div>
+    </div>

--- a/docs/_includes/http/http-code-100.html
+++ b/docs/_includes/http/http-code-100.html
@@ -1,0 +1,102 @@
+<div id='http-code-100'>
+        <h3></h3>
+        <div>
+          <p>
+            Description:<br><br>
+            This check examines the status code returned and whether or not it is 1XX.
+          </p>
+          <br>
+          <p>
+            Tag: <br>
+            <pre><code class='html'>&lt;hedwig-graph data-type="http-code-100" data-height="200" data-width="400" data-unit="other" data={{ someBoundData }} &gt;&lt;/hedwig-graph&gt;</code></pre>
+          </p>
+          <br>
+          <p>Sample data structure</p>
+          <pre><code>
+    [{
+      "code_100": 0,
+      "time": "2018-11-24T18:58:21Z"
+  },
+  {
+      "code_100": 0,
+      "time": "2018-11-25T23:58:21Z"
+  },
+  {
+      "code_100": 0,
+      "time": "2018-11-26T02:58:21Z"
+  },
+  {
+      "code_100": 0,
+      "time": "2018-11-27T10:58:21Z"
+  }]
+            </code></pre>
+            <br><br>
+            <p>
+                Renders: <br>
+              </p>
+              <script>
+                  var mock = [
+                  {
+                    "code_100": 0,
+                    "time": "2018-11-24T18:58:21Z"
+                },
+                {
+                    "code_100": 0,
+                    "time": "2018-11-25T23:58:21Z"
+                },
+                {
+                    "code_100": 0,
+                    "time": "2018-11-26T02:58:21Z"
+                },
+                {
+                    "code_100": 0,
+                    "time": "2018-11-27T10:58:21Z"
+                }];
+
+                  document.write('<hedwig-graph data-type="http-code-100" data-height="200" data-width="400" data-unit="count" data-graph=' + JSON.stringify(mock) + '></hedwig-graph>');
+              </script>
+
+              <p>Options</p>
+              <table class='hxTable hxTable--condensed'>
+                <thead>
+                  <tr>
+                    <th>Name</th>
+                    <th>Required</th>
+                    <th>Default Value</th>
+                  </tr>
+                </thead>
+                <tbody>
+                    <tr>
+                      <td>Type</td>
+                      <td>yes</td>
+                      <td>http-code-100</td>
+                    </tr>
+                  <tr>
+                    <td>Margin</td>
+                    <td>no</td>
+                    <td>{ top: 50, right: 50, bottom: 50, left: 50 }</td>
+                  </tr>
+                  <tr>
+                    <td>Height</td>
+                    <td>no</td>
+                    <td>200</td>
+                  </tr>
+                  <tr>
+                    <td>Weight</td>
+                    <td>no</td>
+                    <td>600</td>
+                  </tr>
+                  <tr>
+                      <td>Line Color</td>
+                      <td>no</td>
+                      <td>#0c7c84</td>
+                    </tr>
+                    <tr>
+                      <td>Unit</td>
+                      <td>no</td>
+                      <td>count</td>
+                    </tr>
+                </tbody>
+              </table>
+        </div>
+    </div>

--- a/docs/_includes/http/http-code-200.html
+++ b/docs/_includes/http/http-code-200.html
@@ -1,0 +1,102 @@
+<div id='http-code-200'>
+        <h3></h3>
+        <div>
+          <p>
+            Description:<br><br>
+            This check examines the status code returned and whether or not it is 2XX.
+          </p>
+          <br>
+          <p>
+            Tag: <br>
+            <pre><code class='html'>&lt;hedwig-graph data-type="http-code-200" data-height="200" data-width="400" data-unit="count" data={{ someBoundData }} &gt;&lt;/hedwig-graph&gt;</code></pre>
+          </p>
+          <br>
+          <p>Sample data structure</p>
+          <pre><code>
+    [{
+      "code_200": 1,
+      "time": "2018-11-24T18:58:21Z"
+  },
+  {
+      "code_200": 1,
+      "time": "2018-11-25T23:58:21Z"
+  },
+  {
+      "code_200": 1,
+      "time": "2018-11-26T02:58:21Z"
+  },
+  {
+      "code_200": 1,
+      "time": "2018-11-27T10:58:21Z"
+  }]
+            </code></pre>
+            <br><br>
+            <p>
+                Renders: <br>
+              </p>
+              <script>
+                  var mock = [
+                  {
+                    "code_200": 1,
+                    "time": "2018-11-24T18:58:21Z"
+                },
+                {
+                    "code_200": 1,
+                    "time": "2018-11-25T23:58:21Z"
+                },
+                {
+                    "code_200": 1,
+                    "time": "2018-11-26T02:58:21Z"
+                },
+                {
+                    "code_200": 1,
+                    "time": "2018-11-27T10:58:21Z"
+                }];
+
+                  document.write('<hedwig-graph data-type="http-code-200" data-height="200" data-width="400" data-unit="count" data-graph=' + JSON.stringify(mock) + '></hedwig-graph>');
+              </script>
+
+              <p>Options</p>
+              <table class='hxTable hxTable--condensed'>
+                <thead>
+                  <tr>
+                    <th>Name</th>
+                    <th>Required</th>
+                    <th>Default Value</th>
+                  </tr>
+                </thead>
+                <tbody>
+                    <tr>
+                      <td>Type</td>
+                      <td>yes</td>
+                      <td>http-code-200</td>
+                    </tr>
+                  <tr>
+                    <td>Margin</td>
+                    <td>no</td>
+                    <td>{ top: 50, right: 50, bottom: 50, left: 50 }</td>
+                  </tr>
+                  <tr>
+                    <td>Height</td>
+                    <td>no</td>
+                    <td>200</td>
+                  </tr>
+                  <tr>
+                    <td>Weight</td>
+                    <td>no</td>
+                    <td>600</td>
+                  </tr>
+                  <tr>
+                      <td>Line Color</td>
+                      <td>no</td>
+                      <td>#0c7c84</td>
+                    </tr>
+                    <tr>
+                      <td>Unit</td>
+                      <td>no</td>
+                      <td>count</td>
+                    </tr>
+                </tbody>
+              </table>
+        </div>
+    </div>

--- a/docs/_includes/http/http-code-300.html
+++ b/docs/_includes/http/http-code-300.html
@@ -1,0 +1,102 @@
+<div id='http-code-300'>
+        <h3></h3>
+        <div>
+          <p>
+            Description:<br><br>
+            This check examines the status code returned and whether or not it is 3XX.
+          </p>
+          <br>
+          <p>
+            Tag: <br>
+            <pre><code class='html'>&lt;hedwig-graph data-type="http-code-300" data-height="200" data-width="400" data-unit="other" data={{ someBoundData }} &gt;&lt;/hedwig-graph&gt;</code></pre>
+          </p>
+          <br>
+          <p>Sample data structure</p>
+          <pre><code>
+    [{
+      "code_300": 0,
+      "time": "2018-11-24T18:58:21Z"
+  },
+  {
+      "code_300": 0,
+      "time": "2018-11-25T23:58:21Z"
+  },
+  {
+      "code_300": 1,
+      "time": "2018-11-26T02:58:21Z"
+  },
+  {
+      "code_300": 0,
+      "time": "2018-11-27T10:58:21Z"
+  }]
+            </code></pre>
+            <br><br>
+            <p>
+                Renders: <br>
+              </p>
+              <script>
+                  var mock = [
+                  {
+                    "code_300": 0,
+                    "time": "2018-11-24T18:58:21Z"
+                },
+                {
+                    "code_300": 0,
+                    "time": "2018-11-25T23:58:21Z"
+                },
+                {
+                    "code_300": 1,
+                    "time": "2018-11-26T02:58:21Z"
+                },
+                {
+                    "code_300": 0,
+                    "time": "2018-11-27T10:58:21Z"
+                }];
+
+                  document.write('<hedwig-graph data-type="http-code-300" data-height="200" data-width="400" data-unit="count" data-graph=' + JSON.stringify(mock) + '></hedwig-graph>');
+              </script>
+
+              <p>Options</p>
+              <table class='hxTable hxTable--condensed'>
+                <thead>
+                  <tr>
+                    <th>Name</th>
+                    <th>Required</th>
+                    <th>Default Value</th>
+                  </tr>
+                </thead>
+                <tbody>
+                    <tr>
+                      <td>Type</td>
+                      <td>yes</td>
+                      <td>http-code-300</td>
+                    </tr>
+                  <tr>
+                    <td>Margin</td>
+                    <td>no</td>
+                    <td>{ top: 50, right: 50, bottom: 50, left: 50 }</td>
+                  </tr>
+                  <tr>
+                    <td>Height</td>
+                    <td>no</td>
+                    <td>200</td>
+                  </tr>
+                  <tr>
+                    <td>Weight</td>
+                    <td>no</td>
+                    <td>600</td>
+                  </tr>
+                  <tr>
+                      <td>Line Color</td>
+                      <td>no</td>
+                      <td>#0c7c84</td>
+                    </tr>
+                    <tr>
+                      <td>Unit</td>
+                      <td>no</td>
+                      <td>count</td>
+                    </tr>
+                </tbody>
+              </table>
+        </div>
+    </div>

--- a/docs/_includes/http/http-code-400.html
+++ b/docs/_includes/http/http-code-400.html
@@ -1,0 +1,102 @@
+<div id='http-code-400'>
+        <h3></h3>
+        <div>
+          <p>
+            Description:<br><br>
+            This check examines the status code returned and whether or not it is 4XX.
+          </p>
+          <br>
+          <p>
+            Tag: <br>
+            <pre><code class='html'>&lt;hedwig-graph data-type="http-code-400" data-height="200" data-width="400" data-unit="other" data={{ someBoundData }} &gt;&lt;/hedwig-graph&gt;</code></pre>
+          </p>
+          <br>
+          <p>Sample data structure</p>
+          <pre><code>
+    [{
+      "code_400": 0,
+      "time": "2018-11-24T18:58:21Z"
+  },
+  {
+      "code_400": 0,
+      "time": "2018-11-25T23:58:21Z"
+  },
+  {
+      "code_400": 0,
+      "time": "2018-11-26T02:58:21Z"
+  },
+  {
+      "code_400": 0,
+      "time": "2018-11-27T10:58:21Z"
+  }]
+            </code></pre>
+            <br><br>
+            <p>
+                Renders: <br>
+              </p>
+              <script>
+                  var mock = [
+                  {
+                    "code_400": 0,
+                    "time": "2018-11-24T18:58:21Z"
+                },
+                {
+                    "code_400": 0,
+                    "time": "2018-11-25T23:58:21Z"
+                },
+                {
+                    "code_400": 0,
+                    "time": "2018-11-26T02:58:21Z"
+                },
+                {
+                    "code_400": 0,
+                    "time": "2018-11-27T10:58:21Z"
+                }];
+
+                  document.write('<hedwig-graph data-type="http-code-400" data-height="200" data-width="400" data-unit="count" data-graph=' + JSON.stringify(mock) + '></hedwig-graph>');
+              </script>
+
+              <p>Options</p>
+              <table class='hxTable hxTable--condensed'>
+                <thead>
+                  <tr>
+                    <th>Name</th>
+                    <th>Required</th>
+                    <th>Default Value</th>
+                  </tr>
+                </thead>
+                <tbody>
+                    <tr>
+                      <td>Type</td>
+                      <td>yes</td>
+                      <td>http-code-400</td>
+                    </tr>
+                  <tr>
+                    <td>Margin</td>
+                    <td>no</td>
+                    <td>{ top: 50, right: 50, bottom: 50, left: 50 }</td>
+                  </tr>
+                  <tr>
+                    <td>Height</td>
+                    <td>no</td>
+                    <td>200</td>
+                  </tr>
+                  <tr>
+                    <td>Weight</td>
+                    <td>no</td>
+                    <td>600</td>
+                  </tr>
+                  <tr>
+                      <td>Line Color</td>
+                      <td>no</td>
+                      <td>#0c7c84</td>
+                    </tr>
+                    <tr>
+                      <td>Unit</td>
+                      <td>no</td>
+                      <td>count</td>
+                    </tr>
+                </tbody>
+              </table>
+        </div>
+    </div>

--- a/docs/_includes/http/http-code-500.html
+++ b/docs/_includes/http/http-code-500.html
@@ -1,0 +1,102 @@
+<div id='http-code-500'>
+        <h3></h3>
+        <div>
+          <p>
+            Description:<br><br>
+            This check examines the status code returned and whether or not it is 5XX.
+          </p>
+          <br>
+          <p>
+            Tag: <br>
+            <pre><code class='html'>&lt;hedwig-graph data-type="http-code-500" data-height="200" data-width="400" data-unit="other" data={{ someBoundData }} &gt;&lt;/hedwig-graph&gt;</code></pre>
+          </p>
+          <br>
+          <p>Sample data structure</p>
+          <pre><code>
+    [{
+      "code_500": 0,
+      "time": "2018-11-24T18:58:21Z"
+  },
+  {
+      "code_500": 0,
+      "time": "2018-11-25T23:58:21Z"
+  },
+  {
+      "code_500": 0,
+      "time": "2018-11-26T02:58:21Z"
+  },
+  {
+      "code_500": 0,
+      "time": "2018-11-27T10:58:21Z"
+  }]
+            </code></pre>
+            <br><br>
+            <p>
+                Renders: <br>
+              </p>
+              <script>
+                  var mock = [
+                  {
+                    "code_500": 0,
+                    "time": "2018-11-24T18:58:21Z"
+                },
+                {
+                    "code_500": 0,
+                    "time": "2018-11-25T23:58:21Z"
+                },
+                {
+                    "code_500": 0,
+                    "time": "2018-11-26T02:58:21Z"
+                },
+                {
+                    "code_500": 0,
+                    "time": "2018-11-27T10:58:21Z"
+                }];
+
+                  document.write('<hedwig-graph data-type="http-code-500" data-height="200" data-width="400" data-unit="count" data-graph=' + JSON.stringify(mock) + '></hedwig-graph>');
+              </script>
+
+              <p>Options</p>
+              <table class='hxTable hxTable--condensed'>
+                <thead>
+                  <tr>
+                    <th>Name</th>
+                    <th>Required</th>
+                    <th>Default Value</th>
+                  </tr>
+                </thead>
+                <tbody>
+                    <tr>
+                      <td>Type</td>
+                      <td>yes</td>
+                      <td>http-code-500</td>
+                    </tr>
+                  <tr>
+                    <td>Margin</td>
+                    <td>no</td>
+                    <td>{ top: 50, right: 50, bottom: 50, left: 50 }</td>
+                  </tr>
+                  <tr>
+                    <td>Height</td>
+                    <td>no</td>
+                    <td>200</td>
+                  </tr>
+                  <tr>
+                    <td>Weight</td>
+                    <td>no</td>
+                    <td>600</td>
+                  </tr>
+                  <tr>
+                      <td>Line Color</td>
+                      <td>no</td>
+                      <td>#0c7c84</td>
+                    </tr>
+                    <tr>
+                      <td>Unit</td>
+                      <td>no</td>
+                      <td>count</td>
+                    </tr>
+                </tbody>
+              </table>
+        </div>
+    </div>

--- a/docs/_includes/http/http-duration.html
+++ b/docs/_includes/http/http-duration.html
@@ -1,0 +1,102 @@
+<div id='http-duration'>
+        <h3></h3>
+        <div>
+          <p>
+            Description:<br><br>
+            The time it took to finish executing the check in milliseconds.
+          </p>
+          <br>
+          <p>
+            Tag: <br>
+            <pre><code class='html'>&lt;hedwig-graph data-type="http-duration" data-height="200" data-width="400" data-unit="milliseconds" data={{ someBoundData }} &gt;&lt;/hedwig-graph&gt;</code></pre>
+          </p>
+          <br>
+          <p>Sample data structure</p>
+          <pre><code>
+    [{
+      "duration": 35,
+      "time": "2018-11-24T18:58:21Z"
+  },
+  {
+      "duration": 38,
+      "time": "2018-11-25T23:58:21Z"
+  },
+  {
+      "duration": 5,
+      "time": "2018-11-26T02:58:21Z"
+  },
+  {
+      "duration": 6,
+      "time": "2018-11-27T10:58:21Z"
+  }]
+            </code></pre>
+            <br><br>
+            <p>
+                Renders: <br>
+              </p>
+              <script>
+                  var mock = [
+                  {
+                    "duration": 35,
+                    "time": "2018-11-24T18:58:21Z"
+                },
+                {
+                    "duration": 38,
+                    "time": "2018-11-25T23:58:21Z"
+                },
+                {
+                    "duration": 5,
+                    "time": "2018-11-26T02:58:21Z"
+                },
+                {
+                    "duration": 6,
+                    "time": "2018-11-27T10:58:21Z"
+                }];
+
+                  document.write('<hedwig-graph data-type="http-duration" data-height="200" data-width="400" data-unit="milliseconds" data-graph=' + JSON.stringify(mock) + '></hedwig-graph>');
+              </script>
+
+              <p>Options</p>
+              <table class='hxTable hxTable--condensed'>
+                <thead>
+                  <tr>
+                    <th>Name</th>
+                    <th>Required</th>
+                    <th>Default Value</th>
+                  </tr>
+                </thead>
+                <tbody>
+                    <tr>
+                      <td>Type</td>
+                      <td>yes</td>
+                      <td>http-duration</td>
+                    </tr>
+                  <tr>
+                    <td>Margin</td>
+                    <td>no</td>
+                    <td>{ top: 50, right: 50, bottom: 50, left: 50 }</td>
+                  </tr>
+                  <tr>
+                    <td>Height</td>
+                    <td>no</td>
+                    <td>200</td>
+                  </tr>
+                  <tr>
+                    <td>Weight</td>
+                    <td>no</td>
+                    <td>600</td>
+                  </tr>
+                  <tr>
+                      <td>Line Color</td>
+                      <td>no</td>
+                      <td>#0c7c84</td>
+                    </tr>
+                    <tr>
+                      <td>Unit</td>
+                      <td>no</td>
+                      <td>count</td>
+                    </tr>
+                </tbody>
+              </table>
+        </div>
+    </div>

--- a/docs/_includes/http/http-truncated.html
+++ b/docs/_includes/http/http-truncated.html
@@ -1,0 +1,102 @@
+<div id='http-truncated'>
+        <h3></h3>
+        <div>
+          <p>
+            Description:<br><br>
+            The number of bytes that the result was truncated by.
+          </p>
+          <br>
+          <p>
+            Tag: <br>
+            <pre><code class='html'>&lt;hedwig-graph data-type="http-truncated" data-height="200" data-width="400" data-unit="b" data={{ someBoundData }} &gt;&lt;/hedwig-graph&gt;</code></pre>
+          </p>
+          <br>
+          <p>Sample data structure</p>
+          <pre><code>
+    [{
+      "truncated": 0,
+      "time": "2018-11-24T18:58:21Z"
+  },
+  {
+      "truncated": 0,
+      "time": "2018-11-25T23:58:21Z"
+  },
+  {
+      "truncated": 0,
+      "time": "2018-11-26T02:58:21Z"
+  },
+  {
+      "truncated": 0,
+      "time": "2018-11-27T10:58:21Z"
+  }]
+            </code></pre>
+            <br><br>
+            <p>
+                Renders: <br>
+              </p>
+              <script>
+                  var mock = [
+                  {
+                    "truncated": 0,
+                    "time": "2018-11-24T18:58:21Z"
+                },
+                {
+                    "truncated": 0,
+                    "time": "2018-11-25T23:58:21Z"
+                },
+                {
+                    "truncated": 0,
+                    "time": "2018-11-26T02:58:21Z"
+                },
+                {
+                    "truncated": 0,
+                    "time": "2018-11-27T10:58:21Z"
+                }];
+
+                  document.write('<hedwig-graph data-type="http-truncated" data-height="200" data-width="400" data-unit="b" data-graph=' + JSON.stringify(mock) + '></hedwig-graph>');
+              </script>
+
+              <p>Options</p>
+              <table class='hxTable hxTable--condensed'>
+                <thead>
+                  <tr>
+                    <th>Name</th>
+                    <th>Required</th>
+                    <th>Default Value</th>
+                  </tr>
+                </thead>
+                <tbody>
+                    <tr>
+                      <td>Type</td>
+                      <td>yes</td>
+                      <td>http-truncated</td>
+                    </tr>
+                  <tr>
+                    <td>Margin</td>
+                    <td>no</td>
+                    <td>{ top: 50, right: 50, bottom: 50, left: 50 }</td>
+                  </tr>
+                  <tr>
+                    <td>Height</td>
+                    <td>no</td>
+                    <td>200</td>
+                  </tr>
+                  <tr>
+                    <td>Weight</td>
+                    <td>no</td>
+                    <td>600</td>
+                  </tr>
+                  <tr>
+                      <td>Line Color</td>
+                      <td>no</td>
+                      <td>#0c7c84</td>
+                    </tr>
+                    <tr>
+                      <td>Unit</td>
+                      <td>no</td>
+                      <td>b</td>
+                    </tr>
+                </tbody>
+              </table>
+        </div>
+    </div>

--- a/docs/_includes/http/http-tt-connect.html
+++ b/docs/_includes/http/http-tt-connect.html
@@ -1,0 +1,102 @@
+<div id='http-tt-connect'>
+        <h3></h3>
+        <div>
+          <p>
+            Description:<br><br>
+            The time to connect measured in milliseconds.
+          </p>
+          <br>
+          <p>
+            Tag: <br>
+            <pre><code class='html'>&lt;hedwig-graph data-type="http-tt-connect" data-height="200" data-width="400" data-unit="milliseconds" data={{ someBoundData }} &gt;&lt;/hedwig-graph&gt;</code></pre>
+          </p>
+          <br>
+          <p>Sample data structure</p>
+          <pre><code>
+    [{
+      "tt_connect": 1,
+      "time": "2018-11-24T18:58:21Z"
+  },
+  {
+      "tt_connect": 1,
+      "time": "2018-11-25T23:58:21Z"
+  },
+  {
+      "tt_connect": 0,
+      "time": "2018-11-26T02:58:21Z"
+  },
+  {
+      "tt_connect": 0,
+      "time": "2018-11-27T10:58:21Z"
+  }]
+            </code></pre>
+            <br><br>
+            <p>
+                Renders: <br>
+              </p>
+              <script>
+                  var mock = [
+                  {
+                    "tt_connect": 1,
+                    "time": "2018-11-24T18:58:21Z"
+                },
+                {
+                    "tt_connect": 1,
+                    "time": "2018-11-25T23:58:21Z"
+                },
+                {
+                    "tt_connect": 0,
+                    "time": "2018-11-26T02:58:21Z"
+                },
+                {
+                    "tt_connect": 0,
+                    "time": "2018-11-27T10:58:21Z"
+                }];
+
+                  document.write('<hedwig-graph data-type="http-tt-connect" data-height="200" data-width="400" data-unit="milliseconds" data-graph=' + JSON.stringify(mock) + '></hedwig-graph>');
+              </script>
+
+              <p>Options</p>
+              <table class='hxTable hxTable--condensed'>
+                <thead>
+                  <tr>
+                    <th>Name</th>
+                    <th>Required</th>
+                    <th>Default Value</th>
+                  </tr>
+                </thead>
+                <tbody>
+                    <tr>
+                      <td>Type</td>
+                      <td>yes</td>
+                      <td>http-tt-connect</td>
+                    </tr>
+                  <tr>
+                    <td>Margin</td>
+                    <td>no</td>
+                    <td>{ top: 50, right: 50, bottom: 50, left: 50 }</td>
+                  </tr>
+                  <tr>
+                    <td>Height</td>
+                    <td>no</td>
+                    <td>200</td>
+                  </tr>
+                  <tr>
+                    <td>Weight</td>
+                    <td>no</td>
+                    <td>600</td>
+                  </tr>
+                  <tr>
+                      <td>Line Color</td>
+                      <td>no</td>
+                      <td>#0c7c84</td>
+                    </tr>
+                    <tr>
+                      <td>Unit</td>
+                      <td>no</td>
+                      <td>milliseconds</td>
+                    </tr>
+                </tbody>
+              </table>
+        </div>
+    </div>

--- a/docs/_includes/http/http-tt-firstbyte.html
+++ b/docs/_includes/http/http-tt-firstbyte.html
@@ -1,0 +1,102 @@
+<div id='http-tt-firstbyte'>
+        <h3></h3>
+        <div>
+          <p>
+            Description:<br><br>
+            The time to first byte measured in milliseconds.
+          </p>
+          <br>
+          <p>
+            Tag: <br>
+            <pre><code class='html'>&lt;hedwig-graph data-type="http-tt-firstbyte" data-height="200" data-width="400" data-unit="milliseconds" data={{ someBoundData }} &gt;&lt;/hedwig-graph&gt;</code></pre>
+          </p>
+          <br>
+          <p>Sample data structure</p>
+          <pre><code>
+    [{
+      "tt_firstbyte": 38,
+      "time": "2018-11-24T18:58:21Z"
+  },
+  {
+      "tt_firstbyte": 38,
+      "time": "2018-11-25T23:58:21Z"
+  },
+  {
+      "tt_firstbyte": 5,
+      "time": "2018-11-26T02:58:21Z"
+  },
+  {
+      "tt_firstbyte": 31,
+      "time": "2018-11-27T10:58:21Z"
+  }]
+            </code></pre>
+            <br><br>
+            <p>
+                Renders: <br>
+              </p>
+              <script>
+                  var mock = [
+                  {
+                    "tt_firstbyte": 38,
+                    "time": "2018-11-24T18:58:21Z"
+                },
+                {
+                    "tt_firstbyte": 38,
+                    "time": "2018-11-25T23:58:21Z"
+                },
+                {
+                    "tt_firstbyte": 5,
+                    "time": "2018-11-26T02:58:21Z"
+                },
+                {
+                    "tt_firstbyte": 31,
+                    "time": "2018-11-27T10:58:21Z"
+                }];
+
+                  document.write('<hedwig-graph data-type="http-tt-firstbyte" data-height="200" data-width="400" data-unit="milliseconds" data-graph=' + JSON.stringify(mock) + '></hedwig-graph>');
+              </script>
+
+              <p>Options</p>
+              <table class='hxTable hxTable--condensed'>
+                <thead>
+                  <tr>
+                    <th>Name</th>
+                    <th>Required</th>
+                    <th>Default Value</th>
+                  </tr>
+                </thead>
+                <tbody>
+                    <tr>
+                      <td>Type</td>
+                      <td>yes</td>
+                      <td>http-tt-firstbyte</td>
+                    </tr>
+                  <tr>
+                    <td>Margin</td>
+                    <td>no</td>
+                    <td>{ top: 50, right: 50, bottom: 50, left: 50 }</td>
+                  </tr>
+                  <tr>
+                    <td>Height</td>
+                    <td>no</td>
+                    <td>200</td>
+                  </tr>
+                  <tr>
+                    <td>Weight</td>
+                    <td>no</td>
+                    <td>600</td>
+                  </tr>
+                  <tr>
+                      <td>Line Color</td>
+                      <td>no</td>
+                      <td>#0c7c84</td>
+                    </tr>
+                    <tr>
+                      <td>Unit</td>
+                      <td>no</td>
+                      <td>milliseconds</td>
+                    </tr>
+                </tbody>
+              </table>
+        </div>
+    </div>

--- a/docs/_includes/nav.html
+++ b/docs/_includes/nav.html
@@ -53,9 +53,24 @@
 <a href='#network-tx-dropped'>network tx dropped</a>
 <a href='#network-tx-collisions'>network tx collisions</a>
 <a href='#network-tx-carrier'>network tx carrier</a>
-<<<<<<< HEAD
 <a href='#network-tx-overruns'>network tx overruns</a>
-=======
 <a href='#network-tx-packets'>network tx packets</a>
->>>>>>> master
+</hx-reveal>
+<hx-disclosure aria-controls="http">HTTP
+    <hx-icon class="toggle-icon" type="angle-down"></hx-icon>
+</hx-disclosure>
+<hx-reveal id="http">
+<a href='#http-bytes'>http bytes</a>
+<a href='#http-cert-bits'>http cert bits</a>
+<a href='#http-cert-end'>http cert end</a>
+<a href='#http-cert-end-in'>http cert end in</a>
+<a href='#http-code-100'>http code 100</a>
+<a href='#http-code-200'>http code 200</a>
+<a href='#http-code-300'>http code 300</a>
+<a href='#http-code-400'>http code 400</a>
+<a href='#http-code-500'>http code 500</a>
+<a href='#http-duration'>http duration</a>
+<a href='#http-truncated'>http truncated</a>
+<a href='#http-tt-connect'>http connect</a>
+<a href='#http-tt-firstbyte'>http firstbyte</a>
 </hx-reveal>

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -133,6 +133,32 @@
 
             {% include network/network-tx-packets.html %}
 
+            <br/><hr /><br/>
+
+            {% include http/http-bytes.html %}
+
+            {% include http/http-cert-bits.html %}
+
+            {% include http/http-cert-end.html %}
+
+            {% include http/http-code-100.html %}
+
+            {% include http/http-code-200.html %}
+
+            {% include http/http-code-300.html %}
+
+            {% include http/http-code-400.html %}
+
+            {% include http/http-code-500.html %}
+
+            {% include http/http-duration.html %}
+
+            {% include http/http-truncated.html %}
+
+            {% include http/http-tt-connect.html %}
+
+            {% include http/http-tt-firstbyte.html %}
+
           </hx-panelbody>
         </hx-panel>
       </main>

--- a/docs/assets/scripts/hedwig-main.umd.js
+++ b/docs/assets/scripts/hedwig-main.umd.js
@@ -6177,6 +6177,12 @@
           case unit === 'collisions':
             return d + ' collisions/s';
 
+          case unit === 'other':
+            return d + ' days';
+
+          case unit === 'milliseconds':
+            return d + ' ms';
+
           default:
             return d + '%';
         }
@@ -6427,6 +6433,62 @@
     	"network-tx-packets": {
     		key: "tx_packets",
     		unit: "packets"
+    	},
+    	"http-bytes": {
+    		key: "bytes",
+    		unit: "b"
+    	},
+    	"http-cert-bits": {
+    		key: "cert_bits",
+    		unit: "b"
+    	},
+    	"http-cert-end": {
+    		key: "cert_end",
+    		unit: "other"
+    	},
+    	"http-cert-end-in": {
+    		key: "cert_end_in",
+    		unit: "other"
+    	},
+    	"http-cert-start": {
+    		key: "cert_start",
+    		unit: "other"
+    	},
+    	"http-code-100": {
+    		key: "code_100",
+    		unit: "count"
+    	},
+    	"http-code-200": {
+    		key: "code_200",
+    		unit: "count"
+    	},
+    	"http-code-300": {
+    		key: "code_300",
+    		unit: "count"
+    	},
+    	"http-code-400": {
+    		key: "code_400",
+    		unit: "count"
+    	},
+    	"http-code-500": {
+    		key: "code_500",
+    		unit: "count"
+    	},
+    	"http-duration": {
+    		key: "duration",
+    		unit: "milliseconds"
+    	},
+    	"http-truncated": {
+    		key: "truncated",
+    		unit: "b"
+    	},
+    	"http-tt-connect": {
+    		key: "tt_connect",
+    		unit: "milliseconds"
+    	},
+    	"http-tt-firstbyte": {
+    		key: "tt_firstbyte",
+    		unit: "milliseconds"
     	}
     };
 

--- a/src/helpers/axisConverter.js
+++ b/src/helpers/axisConverter.js
@@ -35,6 +35,10 @@ export class AxisLeft {
                 return d + ' packets/s';
             case unit === 'collisions':
                 return d + ' collisions/s';
+            case unit === 'other':
+                return d + ' days';
+            case unit === 'milliseconds':
+                return d + ' ms';
             default:
                 return d + '%';
        }

--- a/src/helpers/supported.json
+++ b/src/helpers/supported.json
@@ -152,6 +152,62 @@
         "network-tx-packets" : {
             "key" : "tx_packets",
             "unit": "packets"
+        },
+        "http-bytes" : {
+            "key" : "bytes",
+            "unit": "b"
+        },
+        "http-cert-bits" : {
+            "key" : "cert_bits",
+            "unit": "b"
+        },
+        "http-cert-end" : {
+            "key" : "cert_end",
+            "unit": "other"
+        },
+        "http-cert-end-in" : {
+            "key" : "cert_end_in",
+            "unit": "other"
+        },
+        "http-cert-start" : {
+            "key" : "cert_start",
+            "unit": "other"
+        },
+        "http-code-100" : {
+            "key" : "code_100",
+            "unit": "count"
+        },
+        "http-code-200" : {
+            "key" : "code_200",
+            "unit": "count"
+        },
+        "http-code-300" : {
+            "key" : "code_300",
+            "unit": "count"
+        },
+        "http-code-400" : {
+            "key" : "code_400",
+            "unit": "count"
+        },
+        "http-code-500" : {
+            "key" : "code_500",
+            "unit": "count"
+        },
+        "http-duration" : {
+            "key" : "duration",
+            "unit": "milliseconds"
+        },
+        "http-truncated" : {
+            "key" : "truncated",
+            "unit": "b"
+        },
+        "http-tt-connect" : {
+            "key" : "tt_connect",
+            "unit": "milliseconds"
+        },
+        "http-tt-firstbyte" : {
+            "key" : "tt_firstbyte",
+            "unit": "milliseconds"
         }
     }
 }

--- a/test/components/http/bytes/bytes-free.vis.js
+++ b/test/components/http/bytes/bytes-free.vis.js
@@ -1,0 +1,25 @@
+var scenarioConfig = {};
+
+scenarioConfig.config = (host, port) =>
+{
+    return {
+        "label": `HTTP - bytes`,
+        "url": `${host}:${port}/http/bytes/index.html`,
+        "referenceUrl": ``,
+        "readyEvent": ``,
+        "readySelector": ``,
+        "delay": 0,
+        "hideSelectors": [],
+        "removeSelectors": [],
+        "hoverSelector": ``,
+        "clickSelector": ``,
+        "postInteractionWait": 0,
+        "selectors": [ ],
+        "selectorExpansion": true,
+        "expect": 0,
+        "misMatchThreshold" : 0.1,
+        "requireSameDimensions": true
+    };
+};
+
+module.exports = scenarioConfig;

--- a/test/components/http/bytes/index.html
+++ b/test/components/http/bytes/index.html
@@ -1,0 +1,29 @@
+<html>
+    <head>
+        <script src="../../../../dist/hedwig-main.umd.js"></script>
+    </head>
+    <body>
+        <script>
+            var mock = [
+                {
+                    "bytes": 8958,
+                    "time": "2018-11-24T18:58:21Z"
+                },
+                {
+                    "bytes": 735,
+                    "time": "2018-11-25T23:58:21Z"
+                },
+                {
+                    "bytes": 115,
+                    "time": "2018-11-26T02:58:21Z"
+                },
+                {
+                    "bytes": 742,
+                    "time": "2018-11-27T10:58:21Z"
+                }
+            ];
+
+            document.write('<hedwig-graph data-type="http-bytes" data-unit="b" data-height="400" data-width="1000" data-graph=' + JSON.stringify(mock) + '></hedwig-graph>');
+        </script>
+    </body>
+</html>

--- a/test/components/http/cert-bits/cert-bits.vis.js
+++ b/test/components/http/cert-bits/cert-bits.vis.js
@@ -1,0 +1,25 @@
+var scenarioConfig = {};
+
+scenarioConfig.config = (host, port) =>
+{
+    return {
+        "label": `HTTP - certs-bits`,
+        "url": `${host}:${port}/http/certs-bits/index.html`,
+        "referenceUrl": ``,
+        "readyEvent": ``,
+        "readySelector": ``,
+        "delay": 0,
+        "hideSelectors": [],
+        "removeSelectors": [],
+        "hoverSelector": ``,
+        "clickSelector": ``,
+        "postInteractionWait": 0,
+        "selectors": [ ],
+        "selectorExpansion": true,
+        "expect": 0,
+        "misMatchThreshold" : 0.1,
+        "requireSameDimensions": true
+    };
+};
+
+module.exports = scenarioConfig;

--- a/test/components/http/cert-bits/index.html
+++ b/test/components/http/cert-bits/index.html
@@ -1,0 +1,29 @@
+<html>
+    <head>
+        <script src="../../../../dist/hedwig-main.umd.js"></script>
+    </head>
+    <body>
+        <script>
+            var mock = [
+                {
+                    "cert_bits": 2048,
+                    "time": "2018-11-24T18:58:21Z"
+                },
+                {
+                    "cert_bits": 2048,
+                    "time": "2018-11-25T23:58:21Z"
+                },
+                {
+                    "cert_bits": 2048,
+                    "time": "2018-11-26T02:58:21Z"
+                },
+                {
+                    "cert_bits": 2048,
+                    "time": "2018-11-27T10:58:21Z"
+                }
+            ];
+
+            document.write('<hedwig-graph data-type="http-cert-bits" data-unit="other" data-height="400" data-width="1000" data-graph=' + JSON.stringify(mock) + '></hedwig-graph>');
+        </script>
+    </body>
+</html>

--- a/test/components/http/cert-end-in/cert-end-in.vis.js
+++ b/test/components/http/cert-end-in/cert-end-in.vis.js
@@ -1,0 +1,25 @@
+var scenarioConfig = {};
+
+scenarioConfig.config = (host, port) =>
+{
+    return {
+        "label": `HTTP - certs-end-in`,
+        "url": `${host}:${port}/http/certs-end-in/index.html`,
+        "referenceUrl": ``,
+        "readyEvent": ``,
+        "readySelector": ``,
+        "delay": 0,
+        "hideSelectors": [],
+        "removeSelectors": [],
+        "hoverSelector": ``,
+        "clickSelector": ``,
+        "postInteractionWait": 0,
+        "selectors": [ ],
+        "selectorExpansion": true,
+        "expect": 0,
+        "misMatchThreshold" : 0.1,
+        "requireSameDimensions": true
+    };
+};
+
+module.exports = scenarioConfig;

--- a/test/components/http/cert-end-in/index.html
+++ b/test/components/http/cert-end-in/index.html
@@ -1,0 +1,29 @@
+<html>
+    <head>
+        <script src="../../../../dist/hedwig-main.umd.js"></script>
+    </head>
+    <body>
+        <script>
+            var mock = [
+                {
+                    "cert_end_in": 43575551,
+                    "time": "2018-11-24T18:58:21Z"
+                },
+                {
+                    "cert_end_in": 12385150,
+                    "time": "2018-11-25T23:58:21Z"
+                },
+                {
+                    "cert_end_in": 47204350,
+                    "time": "2018-11-26T02:58:21Z"
+                },
+                {
+                    "cert_end_in": 12385150,
+                    "time": "2018-11-27T10:58:21Z"
+                }
+            ];
+
+            document.write('<hedwig-graph data-type="http-cert-end-in" data-unit="other" data-height="400" data-width="1000" data-graph=' + JSON.stringify(mock) + '></hedwig-graph>');
+        </script>
+    </body>
+</html>

--- a/test/components/http/cert-end/cert-end.vis.js
+++ b/test/components/http/cert-end/cert-end.vis.js
@@ -1,0 +1,25 @@
+var scenarioConfig = {};
+
+scenarioConfig.config = (host, port) =>
+{
+    return {
+        "label": `HTTP - certs-end`,
+        "url": `${host}:${port}/http/certs-end/index.html`,
+        "referenceUrl": ``,
+        "readyEvent": ``,
+        "readySelector": ``,
+        "delay": 0,
+        "hideSelectors": [],
+        "removeSelectors": [],
+        "hoverSelector": ``,
+        "clickSelector": ``,
+        "postInteractionWait": 0,
+        "selectors": [ ],
+        "selectorExpansion": true,
+        "expect": 0,
+        "misMatchThreshold" : 0.1,
+        "requireSameDimensions": true
+    };
+};
+
+module.exports = scenarioConfig;

--- a/test/components/http/cert-end/index.html
+++ b/test/components/http/cert-end/index.html
@@ -1,0 +1,29 @@
+<html>
+    <head>
+        <script src="../../../../dist/hedwig-main.umd.js"></script>
+    </head>
+    <body>
+        <script>
+            var mock = [
+                {
+                    "cert_end": 1593043199,
+                    "time": "2018-11-24T18:58:21Z"
+                },
+                {
+                    "cert_end": 1593043199,
+                    "time": "2018-11-25T23:58:21Z"
+                },
+                {
+                    "cert_end": 1596671999,
+                    "time": "2018-11-26T02:58:21Z"
+                },
+                {
+                    "cert_end": 1596671999,
+                    "time": "2018-11-27T10:58:21Z"
+                }
+            ];
+
+            document.write('<hedwig-graph data-type="http-cert-end" data-unit="other" data-height="400" data-width="1000" data-graph=' + JSON.stringify(mock) + '></hedwig-graph>');
+        </script>
+    </body>
+</html>

--- a/test/components/http/cert-start/cert-start.vis.js
+++ b/test/components/http/cert-start/cert-start.vis.js
@@ -1,0 +1,25 @@
+var scenarioConfig = {};
+
+scenarioConfig.config = (host, port) =>
+{
+    return {
+        "label": `HTTP - cert-start`,
+        "url": `${host}:${port}/http/cert-start/index.html`,
+        "referenceUrl": ``,
+        "readyEvent": ``,
+        "readySelector": ``,
+        "delay": 0,
+        "hideSelectors": [],
+        "removeSelectors": [],
+        "hoverSelector": ``,
+        "clickSelector": ``,
+        "postInteractionWait": 0,
+        "selectors": [ ],
+        "selectorExpansion": true,
+        "expect": 0,
+        "misMatchThreshold" : 0.1,
+        "requireSameDimensions": true
+    };
+};
+
+module.exports = scenarioConfig;

--- a/test/components/http/cert-start/index.html
+++ b/test/components/http/cert-start/index.html
@@ -1,0 +1,29 @@
+<html>
+    <head>
+        <script src="../../../../dist/hedwig-main.umd.js"></script>
+    </head>
+    <body>
+        <script>
+            var mock = [
+                {
+                    "cert_start": 1505174400,
+                    "time": "2018-11-24T18:58:21Z"
+                },
+                {
+                    "cert_start": 1529884800,
+                    "time": "2018-11-25T23:58:21Z"
+                },
+                {
+                    "cert_start": 1533513600,
+                    "time": "2018-11-26T02:58:21Z"
+                },
+                {
+                    "cert_start": 1529884800,
+                    "time": "2018-11-27T10:58:21Z"
+                }
+            ];
+
+            document.write('<hedwig-graph data-type="http-cert-start" data-unit="other" data-height="400" data-width="1000" data-graph=' + JSON.stringify(mock) + '></hedwig-graph>');
+        </script>
+    </body>
+</html>

--- a/test/components/http/code-100/code-100.vis.js
+++ b/test/components/http/code-100/code-100.vis.js
@@ -1,0 +1,25 @@
+var scenarioConfig = {};
+
+scenarioConfig.config = (host, port) =>
+{
+    return {
+        "label": `HTTP - code-100`,
+        "url": `${host}:${port}/http/code-100/index.html`,
+        "referenceUrl": ``,
+        "readyEvent": ``,
+        "readySelector": ``,
+        "delay": 0,
+        "hideSelectors": [],
+        "removeSelectors": [],
+        "hoverSelector": ``,
+        "clickSelector": ``,
+        "postInteractionWait": 0,
+        "selectors": [ ],
+        "selectorExpansion": true,
+        "expect": 0,
+        "misMatchThreshold" : 0.1,
+        "requireSameDimensions": true
+    };
+};
+
+module.exports = scenarioConfig;

--- a/test/components/http/code-100/index.html
+++ b/test/components/http/code-100/index.html
@@ -1,0 +1,29 @@
+<html>
+    <head>
+        <script src="../../../../dist/hedwig-main.umd.js"></script>
+    </head>
+    <body>
+        <script>
+            var mock = [
+                {
+                    "code_100": 0,
+                    "time": "2018-11-24T18:58:21Z"
+                },
+                {
+                    "code_100": 0,
+                    "time": "2018-11-25T23:58:21Z"
+                },
+                {
+                    "code_100": 0,
+                    "time": "2018-11-26T02:58:21Z"
+                },
+                {
+                    "code_100": 0,
+                    "time": "2018-11-27T10:58:21Z"
+                }
+            ];
+
+            document.write('<hedwig-graph data-type="http-code-100" data-unit="count" data-height="400" data-width="1000" data-graph=' + JSON.stringify(mock) + '></hedwig-graph>');
+        </script>
+    </body>
+</html>

--- a/test/components/http/code-200/code-200.vis.js
+++ b/test/components/http/code-200/code-200.vis.js
@@ -1,0 +1,25 @@
+var scenarioConfig = {};
+
+scenarioConfig.config = (host, port) =>
+{
+    return {
+        "label": `HTTP - code-200`,
+        "url": `${host}:${port}/http/code-200/index.html`,
+        "referenceUrl": ``,
+        "readyEvent": ``,
+        "readySelector": ``,
+        "delay": 0,
+        "hideSelectors": [],
+        "removeSelectors": [],
+        "hoverSelector": ``,
+        "clickSelector": ``,
+        "postInteractionWait": 0,
+        "selectors": [ ],
+        "selectorExpansion": true,
+        "expect": 0,
+        "misMatchThreshold" : 0.1,
+        "requireSameDimensions": true
+    };
+};
+
+module.exports = scenarioConfig;

--- a/test/components/http/code-200/index.html
+++ b/test/components/http/code-200/index.html
@@ -1,0 +1,29 @@
+<html>
+    <head>
+        <script src="../../../../dist/hedwig-main.umd.js"></script>
+    </head>
+    <body>
+        <script>
+            var mock = [
+                {
+                    "code_200": 1,
+                    "time": "2018-11-24T18:58:21Z"
+                },
+                {
+                    "code_200": 1,
+                    "time": "2018-11-25T23:58:21Z"
+                },
+                {
+                    "code_200": 1,
+                    "time": "2018-11-26T02:58:21Z"
+                },
+                {
+                    "code_200": 1,
+                    "time": "2018-11-27T10:58:21Z"
+                }
+            ];
+
+            document.write('<hedwig-graph data-type="http-code-200" data-unit="count" data-height="400" data-width="1000" data-graph=' + JSON.stringify(mock) + '></hedwig-graph>');
+        </script>
+    </body>
+</html>

--- a/test/components/http/code-300/code-300.vis.js
+++ b/test/components/http/code-300/code-300.vis.js
@@ -1,0 +1,25 @@
+var scenarioConfig = {};
+
+scenarioConfig.config = (host, port) =>
+{
+    return {
+        "label": `HTTP - code-300`,
+        "url": `${host}:${port}/http/code-300/index.html`,
+        "referenceUrl": ``,
+        "readyEvent": ``,
+        "readySelector": ``,
+        "delay": 0,
+        "hideSelectors": [],
+        "removeSelectors": [],
+        "hoverSelector": ``,
+        "clickSelector": ``,
+        "postInteractionWait": 0,
+        "selectors": [ ],
+        "selectorExpansion": true,
+        "expect": 0,
+        "misMatchThreshold" : 0.1,
+        "requireSameDimensions": true
+    };
+};
+
+module.exports = scenarioConfig;

--- a/test/components/http/code-300/index.html
+++ b/test/components/http/code-300/index.html
@@ -1,0 +1,29 @@
+<html>
+    <head>
+        <script src="../../../../dist/hedwig-main.umd.js"></script>
+    </head>
+    <body>
+        <script>
+            var mock = [
+                {
+                    "code_300": 0,
+                    "time": "2018-11-24T18:58:21Z"
+                },
+                {
+                    "code_300": 0,
+                    "time": "2018-11-25T23:58:21Z"
+                },
+                {
+                    "code_300": 1,
+                    "time": "2018-11-26T02:58:21Z"
+                },
+                {
+                    "code_300": 0,
+                    "time": "2018-11-27T10:58:21Z"
+                }
+            ];
+
+            document.write('<hedwig-graph data-type="http-code-300" data-unit="count" data-height="400" data-width="1000" data-graph=' + JSON.stringify(mock) + '></hedwig-graph>');
+        </script>
+    </body>
+</html>

--- a/test/components/http/code-400/code-400.vis.js
+++ b/test/components/http/code-400/code-400.vis.js
@@ -1,0 +1,25 @@
+var scenarioConfig = {};
+
+scenarioConfig.config = (host, port) =>
+{
+    return {
+        "label": `HTTP - code-400`,
+        "url": `${host}:${port}/http/code-400/index.html`,
+        "referenceUrl": ``,
+        "readyEvent": ``,
+        "readySelector": ``,
+        "delay": 0,
+        "hideSelectors": [],
+        "removeSelectors": [],
+        "hoverSelector": ``,
+        "clickSelector": ``,
+        "postInteractionWait": 0,
+        "selectors": [ ],
+        "selectorExpansion": true,
+        "expect": 0,
+        "misMatchThreshold" : 0.1,
+        "requireSameDimensions": true
+    };
+};
+
+module.exports = scenarioConfig;

--- a/test/components/http/code-400/index.html
+++ b/test/components/http/code-400/index.html
@@ -1,0 +1,29 @@
+<html>
+    <head>
+        <script src="../../../../dist/hedwig-main.umd.js"></script>
+    </head>
+    <body>
+        <script>
+            var mock = [
+                {
+                    "code_400": 0,
+                    "time": "2018-11-24T18:58:21Z"
+                },
+                {
+                    "code_400": 0,
+                    "time": "2018-11-25T23:58:21Z"
+                },
+                {
+                    "code_400": 0,
+                    "time": "2018-11-26T02:58:21Z"
+                },
+                {
+                    "code_400": 0,
+                    "time": "2018-11-27T10:58:21Z"
+                }
+            ];
+
+            document.write('<hedwig-graph data-type="http-code-400" data-unit="count" data-height="400" data-width="1000" data-graph=' + JSON.stringify(mock) + '></hedwig-graph>');
+        </script>
+    </body>
+</html>

--- a/test/components/http/code-500/code-500.vis.js
+++ b/test/components/http/code-500/code-500.vis.js
@@ -1,0 +1,25 @@
+var scenarioConfig = {};
+
+scenarioConfig.config = (host, port) =>
+{
+    return {
+        "label": `HTTP - code-500`,
+        "url": `${host}:${port}/http/code-500/index.html`,
+        "referenceUrl": ``,
+        "readyEvent": ``,
+        "readySelector": ``,
+        "delay": 0,
+        "hideSelectors": [],
+        "removeSelectors": [],
+        "hoverSelector": ``,
+        "clickSelector": ``,
+        "postInteractionWait": 0,
+        "selectors": [ ],
+        "selectorExpansion": true,
+        "expect": 0,
+        "misMatchThreshold" : 0.1,
+        "requireSameDimensions": true
+    };
+};
+
+module.exports = scenarioConfig;

--- a/test/components/http/code-500/index.html
+++ b/test/components/http/code-500/index.html
@@ -1,0 +1,29 @@
+<html>
+    <head>
+        <script src="../../../../dist/hedwig-main.umd.js"></script>
+    </head>
+    <body>
+        <script>
+            var mock = [
+                {
+                    "code_500": 0,
+                    "time": "2018-11-24T18:58:21Z"
+                },
+                {
+                    "code_500": 0,
+                    "time": "2018-11-25T23:58:21Z"
+                },
+                {
+                    "code_500": 0,
+                    "time": "2018-11-26T02:58:21Z"
+                },
+                {
+                    "code_500": 0,
+                    "time": "2018-11-27T10:58:21Z"
+                }
+            ];
+
+            document.write('<hedwig-graph data-type="http-code-500" data-unit="count" data-height="400" data-width="1000" data-graph=' + JSON.stringify(mock) + '></hedwig-graph>');
+        </script>
+    </body>
+</html>

--- a/test/components/http/duration/duration.vis.js
+++ b/test/components/http/duration/duration.vis.js
@@ -1,0 +1,25 @@
+var scenarioConfig = {};
+
+scenarioConfig.config = (host, port) =>
+{
+    return {
+        "label": `HTTP - duration`,
+        "url": `${host}:${port}/http/duration/index.html`,
+        "referenceUrl": ``,
+        "readyEvent": ``,
+        "readySelector": ``,
+        "delay": 0,
+        "hideSelectors": [],
+        "removeSelectors": [],
+        "hoverSelector": ``,
+        "clickSelector": ``,
+        "postInteractionWait": 0,
+        "selectors": [ ],
+        "selectorExpansion": true,
+        "expect": 0,
+        "misMatchThreshold" : 0.1,
+        "requireSameDimensions": true
+    };
+};
+
+module.exports = scenarioConfig;

--- a/test/components/http/duration/index.html
+++ b/test/components/http/duration/index.html
@@ -1,0 +1,29 @@
+<html>
+    <head>
+        <script src="../../../../dist/hedwig-main.umd.js"></script>
+    </head>
+    <body>
+        <script>
+            var mock = [
+                {
+                    "duration": 35,
+                    "time": "2018-11-24T18:58:21Z"
+                },
+                {
+                    "duration": 38,
+                    "time": "2018-11-25T23:58:21Z"
+                },
+                {
+                    "duration": 5,
+                    "time": "2018-11-26T02:58:21Z"
+                },
+                {
+                    "duration": 6,
+                    "time": "2018-11-27T10:58:21Z"
+                }
+            ];
+
+            document.write('<hedwig-graph data-type="http-duration" data-unit="milliseconds" data-height="400" data-width="1000" data-graph=' + JSON.stringify(mock) + '></hedwig-graph>');
+        </script>
+    </body>
+</html>

--- a/test/components/http/truncated/index.html
+++ b/test/components/http/truncated/index.html
@@ -1,0 +1,29 @@
+<html>
+    <head>
+        <script src="../../../../dist/hedwig-main.umd.js"></script>
+    </head>
+    <body>
+        <script>
+            var mock = [
+                {
+                    "truncated": 0,
+                    "time": "2018-11-24T18:58:21Z"
+                },
+                {
+                    "truncated": 0,
+                    "time": "2018-11-25T23:58:21Z"
+                },
+                {
+                    "truncated": 0,
+                    "time": "2018-11-26T02:58:21Z"
+                },
+                {
+                    "truncated": 0,
+                    "time": "2018-11-27T10:58:21Z"
+                }
+            ];
+
+            document.write('<hedwig-graph data-type="http-truncated" data-unit="b" data-height="400" data-width="1000" data-graph=' + JSON.stringify(mock) + '></hedwig-graph>');
+        </script>
+    </body>
+</html>

--- a/test/components/http/truncated/truncated.vis.js
+++ b/test/components/http/truncated/truncated.vis.js
@@ -1,0 +1,25 @@
+var scenarioConfig = {};
+
+scenarioConfig.config = (host, port) =>
+{
+    return {
+        "label": `HTTP - truncated`,
+        "url": `${host}:${port}/http/truncated/index.html`,
+        "referenceUrl": ``,
+        "readyEvent": ``,
+        "readySelector": ``,
+        "delay": 0,
+        "hideSelectors": [],
+        "removeSelectors": [],
+        "hoverSelector": ``,
+        "clickSelector": ``,
+        "postInteractionWait": 0,
+        "selectors": [ ],
+        "selectorExpansion": true,
+        "expect": 0,
+        "misMatchThreshold" : 0.1,
+        "requireSameDimensions": true
+    };
+};
+
+module.exports = scenarioConfig;

--- a/test/components/http/tt-connect/index.html
+++ b/test/components/http/tt-connect/index.html
@@ -1,0 +1,29 @@
+<html>
+    <head>
+        <script src="../../../../dist/hedwig-main.umd.js"></script>
+    </head>
+    <body>
+        <script>
+            var mock = [
+                {
+                    "tt_connect": 1,
+                    "time": "2018-11-24T18:58:21Z"
+                },
+                {
+                    "tt_connect": 1,
+                    "time": "2018-11-25T23:58:21Z"
+                },
+                {
+                    "tt_connect": 0,
+                    "time": "2018-11-26T02:58:21Z"
+                },
+                {
+                    "tt_connect": 0,
+                    "time": "2018-11-27T10:58:21Z"
+                }
+            ];
+
+            document.write('<hedwig-graph data-type="http-tt-connect" data-unit="milliseconds" data-height="400" data-width="1000" data-graph=' + JSON.stringify(mock) + '></hedwig-graph>');
+        </script>
+    </body>
+</html>

--- a/test/components/http/tt-connect/tt-connect.vis.js
+++ b/test/components/http/tt-connect/tt-connect.vis.js
@@ -1,0 +1,25 @@
+var scenarioConfig = {};
+
+scenarioConfig.config = (host, port) =>
+{
+    return {
+        "label": `HTTP - tt connect`,
+        "url": `${host}:${port}/http/tt-connect/index.html`,
+        "referenceUrl": ``,
+        "readyEvent": ``,
+        "readySelector": ``,
+        "delay": 0,
+        "hideSelectors": [],
+        "removeSelectors": [],
+        "hoverSelector": ``,
+        "clickSelector": ``,
+        "postInteractionWait": 0,
+        "selectors": [ ],
+        "selectorExpansion": true,
+        "expect": 0,
+        "misMatchThreshold" : 0.1,
+        "requireSameDimensions": true
+    };
+};
+
+module.exports = scenarioConfig;

--- a/test/components/http/tt-firstbyte/index.html
+++ b/test/components/http/tt-firstbyte/index.html
@@ -1,0 +1,29 @@
+<html>
+    <head>
+        <script src="../../../../dist/hedwig-main.umd.js"></script>
+    </head>
+    <body>
+        <script>
+            var mock = [
+                {
+                    "tt_firstbyte": 38,
+                    "time": "2018-11-24T18:58:21Z"
+                },
+                {
+                    "tt_firstbyte": 38,
+                    "time": "2018-11-25T23:58:21Z"
+                },
+                {
+                    "tt_firstbyte": 5,
+                    "time": "2018-11-26T02:58:21Z"
+                },
+                {
+                    "tt_firstbyte": 31,
+                    "time": "2018-11-27T10:58:21Z"
+                }
+            ];
+
+            document.write('<hedwig-graph data-type="http-tt-firstbyte" data-unit="milliseconds" data-height="400" data-width="1000" data-graph=' + JSON.stringify(mock) + '></hedwig-graph>');
+        </script>
+    </body>
+</html>

--- a/test/components/http/tt-firstbyte/tt-firstbyte.vis.js
+++ b/test/components/http/tt-firstbyte/tt-firstbyte.vis.js
@@ -1,0 +1,25 @@
+var scenarioConfig = {};
+
+scenarioConfig.config = (host, port) =>
+{
+    return {
+        "label": `HTTP - tt firstbyte`,
+        "url": `${host}:${port}/http/tt-firstbyte/index.html`,
+        "referenceUrl": ``,
+        "readyEvent": ``,
+        "readySelector": ``,
+        "delay": 0,
+        "hideSelectors": [],
+        "removeSelectors": [],
+        "hoverSelector": ``,
+        "clickSelector": ``,
+        "postInteractionWait": 0,
+        "selectors": [ ],
+        "selectorExpansion": true,
+        "expect": 0,
+        "misMatchThreshold" : 0.1,
+        "requireSameDimensions": true
+    };
+};
+
+module.exports = scenarioConfig;


### PR DESCRIPTION
## JIRA:
See ticket here 
- https://jira.rax.io/browse/MNRVA-134
- https://jira.rax.io/browse/MNRVA-135
- https://jira.rax.io/browse/MNRVA-136
- https://jira.rax.io/browse/MNRVA-137
- https://jira.rax.io/browse/MNRVA-138
- https://jira.rax.io/browse/MNRVA-139
- https://jira.rax.io/browse/MNRVA-140
- https://jira.rax.io/browse/MNRVA-141
- https://jira.rax.io/browse/MNRVA-142
- https://jira.rax.io/browse/MNRVA-143
- https://jira.rax.io/browse/MNRVA-144
- https://jira.rax.io/browse/MNRVA-145
- https://jira.rax.io/browse/MNRVA-146
- https://jira.rax.io/browse/MNRVA-147

## Description:
This PR represents all HTTP graph components:
 `http-bytes`
`http-cert-bits`
`http-cert-end`
`http-cert-end-in`
`http-code-100`
`http-code-200`
`http-code-300`
`http-code-400`
`http-code-500`
`http-duration`
`http-truncated`
`http-tt-connect`
`http-tt-firstbyte`

## Testing:
`cd docs` && `bundle exec jekyll serve`

## Screenshots:
(if applicable)